### PR TITLE
CI: Add pullapprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,32 @@
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+# Disallow approval of PRs still under development
+always_pending:
+  title_regex: '(WIP|RFC)'
+  labels:
+    - do-not-merge
+    - wip
+    - rfc
+  explanation: 'Work in progress - do not merge'
+
+group_defaults:
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:)'
+    reject_regex: '^(Rejected|-1|:-1:)'
+  reset_on_push:
+    enabled: false
+  reset_on_reopened:
+    enabled: false
+  author_approval:
+    ignored: true
+
+groups:
+  approvers:
+    required: 2
+    teams:
+      - community


### PR DESCRIPTION
Add a Pullapprove config file to require 2 ack's for all PRs.

Fixes #12.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>