### PR TITLE
docs: Remove stray bracket from contributing doc command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ body:
      $ cd $GOPATH/src/github.com/opencontainers/runc
      $ old_commit="..."
      $ new_commit="..."
-     $ git log --no-merges --abbrev-commit --pretty=oneline "${old_commit}..${new_commit}") | sed 's/^/    /g'
+     $ git log --no-merges --abbrev-commit --pretty=oneline "${old_commit}..${new_commit}" | sed 's/^/    /g'
      ```
 
   Paste the output of the previous command directly into the commit "as-is".


### PR DESCRIPTION
The CONTRIBUTING doc contained an extraneous command in the
"Re-vendor PRs" section which makes the command invalid.

Fixes #49.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>