### PR TITLE
docs: Make contact details more prominent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,16 +341,8 @@ I love it! Very clean code and great tests. lgtm.
 
 ## Contact
 
-The Kata Containers community can be reached through its dedicated IRC
-channels, Slack channels, and mailing lists:
-
-* IRC:
-  * Development discussions: `#kata-dev @ freenode.net`.
-  * General discussions: `#kata-general @ freenode.net`.
-
-* [Slack channels](https://katacontainers.slack.com/) ([invite](http://bit.ly/KataSlack)).
-
-* [Mailing lists](http://lists.katacontainers.io/).
+The Kata Containers community can be reached
+[through various channels](README.md#join-us).
 
 ## Project maintainers
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 * [About Kata Containers](#about-kata-containers)
 * [Community](#community)
+    * [Join Us](#join-us)
     * [Users](#users)
     * [Contributors](#contributors)
 * [Governance](#governance)
@@ -22,6 +23,22 @@ Kata Containers combines technology from [Intel® Clear Containers](https://gith
 # Community
 
 Kata Containers is working to build a global, diverse and collaborative community. Anyone who is interested in supporting the technology is welcome to participate. We are seeking different expertise and skills, ranging from development, operations, documentation, marketing, community organization and product management.
+
+## Join Us
+
+You can join our community on any of the following places:
+
+* Join our [mailing list](http://lists.katacontainers.io/).
+
+* Use the `irc.freenode.net` IRC server to join the discussions:
+  * General discussions channel: [`#kata-general`](http://webchat.freenode.net/?channels=kata-general).
+  * Development discussions channel: [`#kata-dev`](http://webchat.freenode.net/?channels=kata-dev).
+
+* Get an [invite to our Slack channel](http://bit.ly/KataSlack),
+  and then [join us on Slack](https://katacontainers.slack.com/).
+
+* Follow us on [Twitter](https://twitter.com/KataContainers) or
+  [Facebook](https://www.facebook.com/KataContainers).
 
 ## Users
 


### PR DESCRIPTION
Move the contact details to the top-level README in a new "Join Us" section.

This PR is based on (and replaces) https://github.com/kata-containers/community/pull/23.

Fixes #51.

Contributions-from: Josh Berkus <jberkus@redhat.com>
Contributions-from: Kristi Rifenbark <kristix.rifenbark@intel.com>
Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>