### PR TITLE
Docs: Adds Sept 2018 Arch Committee Election

### DIFF
--- a/elections/arch-committee-2018-09/README.md
+++ b/elections/arch-committee-2018-09/README.md
@@ -1,0 +1,15 @@
+# Architecture Committee Elections: September 2018
+
+There are three Architecture Committee seats up for election. The seats up for
+election are currently filled by Wei Zhang, Tim Allclair, and Jessie Frazelle.
+
+Refer to the [elections folder README.md](https://github.com/kata-containers/community/tree/master/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* August 20, 1500 UTC - August 27, 2018 14:59 UTC: Candidate nominations open
+* August 27, 1500 UTC - September 3, 2018 14:59 UTC: Q&A/Debate period
+* September 3, 1500 UTC - September 10, 2018 14:59 UTC: Voting open
+* Week of September 11, 2018, results announced
+


### PR DESCRIPTION
Adds a folder for the September 2018 Architecture Committee
election and a README.md for election dates and times.

Signed-off-by: Anne Bertucio <anne@openstack.org>