### PR TITLE
Adds 2018-09 Election Results

### DIFF
--- a/elections/arch-committee-2018-09/2018-09-Results.txt
+++ b/elections/arch-committee-2018-09/2018-09-Results.txt
@@ -1,0 +1,7 @@
+Architecture Committee Election
+September 10, 2018
+
+Results:
+1) Eric Ernst (egernst)
+2) Wei Zhang (WeiZhang555)
+3) Jon Olson (jon)


### PR DESCRIPTION
Adds the election results for the September
2018 Architecture Committee election.

Signed-off-by: Anne Bertucio <anne@openstack.org>