### PR TITLE
docs: contrib: document stable branch backports

### DIFF
--- a/Backport-Guide.md
+++ b/Backport-Guide.md
@@ -1,0 +1,102 @@
+# Kata Containers stable backport workflow
+
+* [Backport Workflow](#backport-workflow)
+
+This document provides a short guide on how to perform a stable backport of a
+PR or patchset in the Kata Containers repositories.
+
+It does not cover all eventualities that might be encountered while performing
+a backport, and only documents one potential Git based workflow. It does
+serve as a short introduction and reminder of the basic stable backport process.
+
+## Backport Workflow
+
+The basic workflow involves creating a new local branch from the stable tree you
+are targetting, then cherry picking the commits from your master branch PR
+onto that branch. You then submit your branch to GitHub as a PR against the
+stable branch (and not the `master` branch).
+
+The following example shows a pseudo-backport of a PR from the `master` branch
+into the `stable-1.2` branch of the `runtime` repo.
+
+- Ensure your local repo is up to date:
+
+    ```bash
+    $ cd ${GOPATH}/src/github.com/kata-containers/runtime
+    $ git fetch origin
+    ```
+
+    And check the list of current stable branches:
+
+    ```bash
+    $ cd ${GOPATH}/src/github.com/kata-containers/runtime
+    $ git branch -r | grep origin/stable
+    ```
+
+- Create your branch to work on:
+
+    ```bash
+    $ git checkout -b my_1.2_pr_backport origin/stable-1.2
+    ```
+
+- Locate the commits you want to pull in:
+
+    Here we look in the `master` branch, presuming the PR has been merged.
+    If you have the PR in a local branch you can substitute `master` for the name
+    of that branch.
+
+    ```bash
+    $ git log --oneline master
+    # And search for the SHA of the commits you wish to backport.
+    ```
+
+- Pull in your commits:
+
+    If you are pulling the commits in from the `master` branch, you can add the `-x`
+    argument to `git cherry-pick` to automatically add a reference in the
+    commit to the original commits. This is strongly recommended to aid traceability.
+    If you pick the commits from your local branch do *not* use `-x`. This
+    potentially adds references to SHAs that only exist in your user branches, which
+    is not be useful for future tracability.
+
+    It is also required that you add the `-s` signoff to the commits, if you did not
+    create the original commits.
+
+    ```bash
+    $ git cherry-pick -x <commit>...
+    ```
+
+    You can cherry pick ranges of commits, etc. Please see the `git-cherry-pick(1)`
+    man page for more information.
+
+    > *Note:* You do not need to open a new `Issue` for or add an extra `Fixes: nnn` item
+    > to the commits. They should re-use the `Fixes:` entry from the original commits,
+    > so all related commits refer back to the common Issue. It does not matter that
+    > the original `Issue` is closed, the references still work correctly.
+
+- Resolve any conflicts, etc.:
+
+    You might encounter conflicts during your cherry pick, which need to be resolved
+    before you continue. Follow standard practices for Git conflict resolution, and see
+    the guidance printed by `git cherry-pick` on processing and applying those fixes.
+
+    If you hit a conflict, any effects of `-x` to `cherry-pick` might not be
+    applied. In this case, consider hand-adding the `master` SHA references and a note
+    that you resolved a conflict to the commit message.
+
+- Test your changes:
+
+    Before you push your changes, you should test that they work and nothing has been
+    broken. No matter how small the change, running the test suite is always recommended.
+
+- Push your branch to your GitHub repo:
+
+    ```bash
+    $ git push my_remote my_1.2_pr_backport
+    ```
+
+- Submit a PR from your branch to *the stable branch*:
+
+    When you submit your PR on GitHub, make sure to choose the stable branch that you
+    based your branch on and are submitting to. This *should* be the same as the
+    base branch for the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
     * [Normal PR workflow](#normal-pr-workflow)
     * [Assisted PR workflow](#assisted-pr-workflow)
     * [Re-vendor PRs](#re-vendor-prs)
+    * [Stable branch backports](#stable-branch-backports)
 * [Patch format](#patch-format)
     * [General format](#general-format)
     * [Subsystem](#subsystem)
@@ -105,6 +106,10 @@ name.
 By default, GitHub copies the message from your first patch, which is often
 appropriate. However, ensure your message is accurate and complete for the
 entire PR because it ends up in the Git log as the merge message.
+
+You should also assign any appropriate GitHub labels to your PR. This
+is particularly relevant to maintain stable backports. See the
+[Stable branch backports](#stable-branch-backports) section for more details.
 
 Your PR might get feedback and comments, and require rework. The recommended
 procedure for reworking is to redo your branch to a clean state and "force
@@ -236,6 +241,30 @@ body:
 
 For additional information on using the `dep` tool, see
 "[Performing vendoring for the Kata Containers project](https://github.com/kata-containers/community/blob/master/VENDORING.md)".
+
+### Stable branch backports
+
+Kata Containers maintains a number of stable branch releases. Bug fixes to the
+master branch are selectively applied to (or 'backported') these stable branches.
+
+In order to aid identification of commits that potentially should be backported to
+the stable branches, all PRs submitted must be labelled with one or more of the
+following labels. At least one label that is *not* `stable-candidate` must
+be included.
+
+| Label              | Meaning |
+| -----              | ------- |
+| `bug`              | A bug fix, which will potentially be a backport candidate |
+| `cleanup`          | A cleanup, which will likely not be backported                 |
+| `feature`          | A new feature/enhancement, that will likely not be backported  |
+| `stable-candidate` | A PR selected for backporting - very likely a bug fix          |
+| `vendor`           | A golang vendor update. Might be considered for backport if the vendor update includes critical bug fixes |
+
+In the event that a bug fix PR is selected for backporting to the stable branches,
+the `stable-candidate` label is added if not already present, and the original author
+of the PR is asked if they will submit the relevant backport PRs. For a quick guide
+on how to perform and submit a backport, see the [Backport Guide](Backport-Guide.md)
+in this repository.
 
 ## Patch format
 


### PR DESCRIPTION
Add some docs to note we require bug/feature labels on PRs
so we can work out what needs to be a stable backport or not.
Also add a brief doc on how to cherry pick and base/push to
a stable branch PR.

Fixes: #63

Signed-off-by: Graham Whaley <graham.whaley@intel.com>