### PR TITLE
VMT: CVE-2019-5736: runc escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,5 @@ Vulnerability Management Team (VMT). Vulnerabilities are managed using a
 Details of how to report a vulnerability, the process and procedures
 used for vulnerability management, and responsibilites of the VMT members
 can be found in the [VMT documentation](VMT/VMT.md).
+
+Previous Kata Containers Security Advisories are [listed on their own page](VMT/KCSA.md).

--- a/VMT/KCSA.md
+++ b/VMT/KCSA.md
@@ -1,0 +1,9 @@
+# Kata Containers Security Advisories
+
+This page lists all previously published Kata Containers Security Advisories (KCSA)
+
+This table is in reverse date order.
+
+| KCSA                                             | Description                  |
+| ------------------------------------------------ | ---------------------------- |
+| [KCSA-CVE-2019-5736](KCSA/KCSA-CVE-2019-5736.md) | runc container breakout      |

--- a/VMT/KCSA/KCSA-CVE-2019-5736.md
+++ b/VMT/KCSA/KCSA-CVE-2019-5736.md
@@ -1,0 +1,49 @@
+announcement-date: 2019-02-22
+
+id: KCSA-CVE-2019-5736
+
+title: CVE-2019-5736 'runc container breakout' assessment
+
+description: Impact of CVE-2019-5736 on Kata Containers
+
+potentially-affected-components:
+
+  - components: kata-agent
+    version: all
+
+vulnerabilities:
+
+  - cve-id: CVE-2019-5736
+
+reporters:
+
+  - name: Graham Whaley
+    affiliation: VMT member
+    reported:
+      - Original report seen on dev@opencontainers.org
+      - oss-sec posting: https://seclists.org/oss-sec/2019/q1/119
+      - MITRE: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736
+
+issues:
+
+  links:
+    - https://github.com/kata-containers/community/issues/85
+
+  reviews:
+    - no fix required. No PR raised.
+
+reproduce:
+  - Exploit does not effect Kata Containers.
+
+notes:
+  - The CVE-2019-5736 does not affect Kata Containers. Kata Containers does use the
+    runc libcontainer library as part of its 'kata-agent' to launch container workloads, but
+    the kata-agent executable is a permanently running application within the Kata Containers
+    VM. Thus, the exit/re-execute cycle utilised by CVE-2019-5736 to execute the injected code
+    is never undertaken.
+  - It should be noted, if the exploit had escaped from the kata-agent, the exploit code
+    would have been executing inside the Kata Containers VM as root, and would not have direct
+    access to either the host system or other container/pods.
+  - It is highly likely Kata Containers will vendor in and adopt all relevant libcontainer updates
+    and changes, but given the 'copying' nature of some fixes, a performance and resource impact
+    review will be undertaken.


### PR DESCRIPTION
Add the KCSA for CVE-2019-5736.
As this is our first KCSA, also create the KCSA index page and
reference that from the top level README.

Fixes: #85