### PR TITLE
README: Add link to resource owners wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     * [Users](#users)
     * [Contributors](#contributors)
     * [Review Team](#review-team)
+    * [Resource Owners](#resource-owners)
 * [Governance](#governance)
     * [Developers](#developers)
         * [Contributor](#contributor)
@@ -55,6 +56,11 @@ See the [contributing guide](CONTRIBUTING.md) for details on how to contribute t
 ## Review Team
 
 See the [rota documentation](Rota-Process.md).
+
+## Resource Owners
+
+Details of which Kata Containers project resources are owned, managed or controlled by whom
+are detailed on the [Areas of Intetest](https://github.com/kata-containers/community/wiki/Areas-of-interest) wiki page, under the [Resource Owners](https://github.com/kata-containers/community/wiki/Areas-of-interest#resource-owners) section.
 
 # Governance
 


### PR DESCRIPTION
Now we have the table of Kata resources and owners on a wiki page,
let's link it from the main community README to make it easier
to find.

Fixes: #71

Signed-off-by: Graham Whaley <graham.whaley@intel.com>