### PR TITLE
docs: Update Slack invitation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can join our community on any of the following places:
   * General discussions channel: [`#kata-general`](http://webchat.freenode.net/?channels=kata-general).
   * Development discussions channel: [`#kata-dev`](http://webchat.freenode.net/?channels=kata-dev).
 
-* Get an [invite to our Slack channel](http://bit.ly/KataSlack),
+* Get an [invite to our Slack channel](https://bit.ly/katacontainersslack),
   and then [join us on Slack](https://katacontainers.slack.com/).
 
 * Follow us on [Twitter](https://twitter.com/KataContainers) or


### PR DESCRIPTION
The Slack invitation URL expired (boo!) so update to the new one.

Fixes: #130.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>