### PR TITLE
architecture-committee: Update Eric's employer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The Architecture Committee is responsible for architectural decisions, including
 
 The current Architecture Committee members are:
 
-- `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Ampere Computing](https://amperecomputing.com/).
+- `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Apple](https://apple.com/).
 - `Samuel Ortiz` ([`sameo`](https://github.com/sameo)), [Intel](https://www.intel.com).
 - `Justin He` ([`justin-he`](https://github.com/justin-he)), [ARM](https://www.arm.com).
 - `Xu Wang` ([`gnawux`](https://github.com/gnawux)), [Ant Financial](https://www.antfin.com/index.htm?locale=en_US).


### PR DESCRIPTION
Moved again, let's make it official.

Fixes: #160

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>