### PR TITLE
README: Update Architecture Committee members

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ The current Architecture Committee members are:
 
 - `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Apple](https://apple.com/).
 - `Samuel Ortiz` ([`sameo`](https://github.com/sameo)), [Intel](https://www.intel.com).
-- `Justin He` ([`justin-he`](https://github.com/justin-he)), [ARM](https://www.arm.com).
+- `Archana Shinde` ([`amshinde`](https://github.com/amshinde)), [Intel](https://www.intel.com).
 - `Xu Wang` ([`gnawux`](https://github.com/gnawux)), [Ant Financial](https://www.antfin.com/index.htm?locale=en_US).
-- `Haomin Tsai` ([`jshachm`](https://github.com/jshachm)), [Huawei](http://www.huawei.com).
+- `Fabiano Fidêncio` ([`fidencio`](https://github.com/fidencio)), [Red Hat](http://www.redhat.com).
 
 Architecture Committee elections take place in September (3 seats available) and February (2 seats available). Anyone who has made contributions to the project will be eligible to run, and anyone who has had code merged into the Kata Containers project in the 12 months (a Contributor) before the election will be eligible to vote. There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization. The Architecture Committee will meet regularly in an open forum with times and locations published in community channels.
 


### PR DESCRIPTION
As a result of the elections that took place in Sep - Oct 2020,
Archana Shinde and Fabiano Fidêncio became part of the Architecture
Committee.

Fixes: #185

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>