### PR TITLE
security: Create KCSA for CVS-2020-27151

### DIFF
--- a/VMT/KCSA.md
+++ b/VMT/KCSA.md
@@ -11,6 +11,7 @@ This table lists all previously published Kata Containers Security Advisories ([
 
 | Date       | [KCSA]                                             | Affected Versions  | Description                                         |
 | ---------- | -------------------------------------------------- | ------------------ | --------------------------------------------------- |
+| 2020-12-03 | [KCSA-CVE-2020-27151](KCSA/KCSA-CVE-2020-27151.md) | < 1.11.5           | Executing host binaries using annotations           |
 | 2020-11-17 | [KCSA-CVE-2020-28914](KCSA/KCSA-CVE-2020-28914.md) | < 1.11.5           | Improper file permissions for read-only volumes     |
 | 2020-06-12 | [KCSA-CVE-2020-2026](KCSA/KCSA-CVE-2020-2026.md)   | < 1.10.5, < 1.11.1 | Improper link resolution before file access         |
 | 2020-06-12 | [KCSA-CVE-2020-2023](KCSA/KCSA-CVE-2020-2023.md)   | < 1.11.1           | Execution with unnecessary privileges               |

--- a/VMT/KCSA/KCSA-CVE-2020-27151.md
+++ b/VMT/KCSA/KCSA-CVE-2020-27151.md
@@ -1,0 +1,94 @@
+announcement-date: 2020-12-03
+
+id: KCSA-CVE-2020-27151
+
+title: Some `kata-runtime` annotations can execute arbitrary programs
+
+description: An insufficient validation of annotations affects Kata Containers
+prior to version 1.11.5, making it possible to execute arbitrary programs on the
+host. Unless specific filtering of the annotations is performed by the upper
+layers of the stack, it makes it possible for a user to send manifests that
+instruct `kata-runtime` to execute arbitrary code with the same privilege level as
+`kata-runtime` itself.
+
+affected-components:
+
+ - components: `kata-runtime`
+
+ - version: Before v1.11.5
+
+vulnerabilities:
+
+ - CVE-ID: [CVE-2020-27151](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-27151)
+
+reporters:
+
+ - name: `Christophe de Dinechin`
+
+ - affiliation: Red Hat
+
+ - reported:
+
+   - [CVE-2020-27151](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-27151)
+
+issues:
+
+  links:
+
+   - original report: https://bugs.launchpad.net/katacontainers.io/+bug/1878234
+
+   - version 1.11.4: https://github.com/kata-containers/runtime/issues/3004
+
+   - version 2.0: https://github.com/kata-containers/kata-containers/issues/901
+
+ reviews:
+
+  Embargoed:
+
+   - https://github.com/kata-containers/runtime-CVE-2020-27151/pull/1
+
+  Public review:
+
+   - https://github.com/kata-containers/runtime/pull/3005
+
+  v2.0.0:
+
+   - https://github.com/kata-containers/kata-containers/pull/902
+
+  v1.12.0:
+
+   - https://github.com/kata-containers/runtime/pull/3059
+
+  v1.11.5:
+
+   - https://github.com/kata-containers/runtime/pull/3058
+
+  type: GitHub
+
+reproduce:
+
+ - When using a Kubernetes with the Kata Containers runtime enabled, starting a
+   pod with an annotation like the following will execute the binary called
+   `/usr/local/bin/hello` and pass it arguments `arg1` and `arg2`.
+
+```
+       io.katacontainers.config.hypervisor.virtio_fs_daemon: "/usr/local/bin/hello"
+       io.katacontainers.config.hypervisor.virtio_fs_extra_args: "[ \"arg1\", \"arg2\" ]"
+```
+
+ - As an illustration, passing `/usr/sbin/shutdown` as the binary name and `-h`,
+   `now` as the arguments will shutdown the host machine instead of executing
+   the container.
+
+notes:
+
+  - The annotation corresponding to the `virtiofsd` path is the most susceptible
+    to be exploited that way, because another annotation makes it possible to
+    pass parameters to the binary being executed.
+
+  - This vulnerability has been fixed in releases 1.12.0, 1.11.5 and 2.0 branch.
+    The fixed versions provide annotation filters that can be configured by a
+    system administrator, listing the names that are allowed for each of the
+    binaries that `kata-runtime` is susceptible to launch. Additional filtering
+    was added for the paths of host system files that `kata-runtime` needs to
+    access, such as the location of the `/dev/random` device.


### PR DESCRIPTION
An insufficient validation of annotations affects Kata Containers prior to
version 1.11.5, making it possible to execute arbitrary programs on the
host. Unless specific filtering of the annotations is performed by the upper
layers of the stack, it makes it possible for a user to send manifests that
instruct kata-runtime to execute arbitrary code with the same privilege level as
kata-runtime itself.

Fixes: #191

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>