### PR TITLE
elections: Adjust the dates for the 2021-02 round 2

### DIFF
--- a/elections/arch-committee-2021-02/README.md
+++ b/elections/arch-committee-2021-02/README.md
@@ -8,7 +8,7 @@ for election process, declaring candidacy, and eligible voters.
 
 Election Dates:
 
-* February 24, 15:00 UTC - March 3, 2021 14:59 UTC: Candidate nominations open
-* March 4, 15:00 UTC - March 15, 2021 14:59 UTC: Q&A/Debate period
-* March 16, 15:00 UTC - March 22, 2021 14:59 UTC: Voting open
-* March 23, 2021, results announced
+* February 24, 15:00 UTC - March 10, 2021 14:59 UTC: Candidate nominations open
+* March 11, 15:00 UTC - March 22, 2021 14:59 UTC: Q&A/Debate period
+* March 23, 15:00 UTC - March 29, 2021 14:59 UTC: Voting open
+* March 30, 2021, results announced


### PR DESCRIPTION
Due to issues with the Kata Containers ML, the Architecture Committee
has agreed on postponing the election by one week.

This PR updates the dates according to the decision taken as part of the
Architecture Committee meeting held on March 2nd, 2021.

Fixes: #200

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>