### PR TITLE
election: Publish results for 2021-02 round

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The current Architecture Committee members are:
 - `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Apple](https://apple.com/).
 - `Samuel Ortiz` ([`sameo`](https://github.com/sameo)), [Intel](https://www.intel.com).
 - `Archana Shinde` ([`amshinde`](https://github.com/amshinde)), [Intel](https://www.intel.com).
-- `Xu Wang` ([`gnawux`](https://github.com/gnawux)), [Ant Financial](https://www.antfin.com/index.htm?locale=en_US).
+- `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [Ant Financial](https://www.antfin.com/index.htm?locale=en_US).
 - `Fabiano Fidêncio` ([`fidencio`](https://github.com/fidencio)), [Red Hat](http://www.redhat.com).
 
 Architecture Committee elections take place in September (3 seats available) and February (2 seats available). Anyone who has made contributions to the project will be eligible to run, and anyone who has had code merged into the Kata Containers project in the 12 months (a Contributor) before the election will be eligible to vote. There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization.

--- a/elections/arch-committee-2021-02/Results.md
+++ b/elections/arch-committee-2021-02/Results.md
@@ -1,2 +1,11 @@
 # Architecture Committee Election Results: February 2021
 
+Two nominations were received for the February 2021 elections:
+
+- [`Peng Tao`](https://github.com/bergwolf)
+- [`Samuel Ortiz`](https://github.com/sameo)
+
+Two seats were available, so elections were over sooner.
+
+The two members were (re-)admitted to the Architecture Committee on 2021-03-10
+for another 12 month term.


### PR DESCRIPTION
Two nominations were received for the February 2021 elections:

- [`Peng Tao`](https://github.com/bergwolf)
- [`Samuel Ortiz`](https://github.com/sameo)

Two seats were available, so elections were over sooner.

The two members were (re-)admitted to the Architecture Committee on 2021-03-10

Fixes: #207

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>