### PR TITLE
docs: Add note for Windows users to use LF and not CRLF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,15 @@ For more details, see how to [set up a git remote](https://help.github.com/artic
     $ $EDITOR CONTRIBUTING.md
     ```
 
+   >**Note:** If editing in Windows make sure that all documents end with LF
+   > and not CRLF. The CI system will fail if carriage returns are in the
+   > document. Many editors support the ability to change this. There is a
+   > tool called dos2unix available on Git Bash for Windows and also available
+   > on Linux systems that can convert files to LF endings. See the
+   > [Configuring Git to handle line endings](https://docs.github.com/en/github/getting-started-with-github/getting-started-with-git/configuring-git-to-handle-line-endings)
+   > guide for more details on how to configure `git` to automatically insert
+   > the correct line endings.
+
 1. Commit your changes to the current (`fix-contrib-bugs`) branch. Assure
    you use the correct [patch format](#patch-format):
 


### PR DESCRIPTION
If you edit a doc in Windows there is a good chance the
editor will add CRLF to the end instead of LF which
causes CI failures.

Fixes: 210

Signed-off-by: Eric Adams <eric.adams@intel.com>