### PR TITLE
election: Publish results for 2022-03 round

### DIFF
--- a/elections/arch-committee-2022-03/Results.md
+++ b/elections/arch-committee-2022-03/Results.md
@@ -1,2 +1,11 @@
 # Architecture Committee Election Results: March 2022
 
+Two nominations were received for the March 2022 elections:
+
+- [`Peng Tao`](https://github.com/bergwolf)
+- [`Samuel Ortiz`](https://github.com/sameo)
+
+Two seats were available, so elections were over sooner.
+
+The two members were (re-)admitted to the Architecture Committee on 2021-03-16
+for another 12 month term.


### PR DESCRIPTION
Two nominations were received for the March 2022 elections:

- [`Peng Tao`](https://github.com/bergwolf)
- [`Samuel Ortiz`](https://github.com/sameo)

Two seats were available, so elections were over sooner.

The two members were (re-)admitted to the Architecture Committee on 2022-03-16

Fixes: #255

Signed-off-by: bin liu <liubin0329@gmail.com>