### PR TITLE
updated Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can join our community on any of the following places:
   * General discussions channel: [`#kata-general`](http://webchat.oftc.net/?channels=kata-general).
   * Development discussions channel: [`#kata-dev`](http://webchat.oftc.net/?channels=kata-dev).
 
-* Get an [invite to our Slack channel](http://bit.ly/kataslack).
+* Get an [invite to our Slack channel](https://bit.ly/3bbRXOV).
   and then [join us on Slack](https://katacontainers.slack.com/).
 
 * Follow us on [Twitter](https://twitter.com/KataContainers) or


### PR DESCRIPTION
Updated bit.ly link pointing to expired Slack invite to a working link