### PR TITLE
readme: Update Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can join our community on any of the following places:
   * General discussions channel: [`#kata-general`](http://webchat.oftc.net/?channels=kata-general).
   * Development discussions channel: [`#kata-dev`](http://webchat.oftc.net/?channels=kata-dev).
 
-* Get an [invite to our Slack channel](http://bit.ly/kataslack).
+* Get an [invite to our Slack channel](https://bit.ly/3bbRXOV).
   and then [join us on Slack](https://katacontainers.slack.com/).
 
 * Follow us on [Twitter](https://twitter.com/KataContainers) or

--- a/elections/tools/generate_electorate.py
+++ b/elections/tools/generate_electorate.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+#
+# Copyright (c) 2023 Kata Contributors
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Description: Generate a list of kata contributors by extracting contact


### PR DESCRIPTION
I came across this issue today when I tried to sign-up to kata slack, so I took the liberty to refresh the PR.

Updated bit.ly link pointing to expired Slack invite to a working link.

Fixes: #315
Originally-by: OGtrilliams <tribecca@tribecc.us>
Closes: #316