### PR TITLE
elections: 2023-04 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ The Architecture Committee is responsible for architectural decisions, including
 
 The current Architecture Committee members are:
 
-- `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Apple](https://apple.com/).
-- `Samuel Ortiz` ([`sameo`](https://github.com/sameo)), [`Rivos Inc`](https://www.rivosinc.com/).
-- `Gerry Liu` ([`jiangliu`](https://github.com/jiangliu)), [`Alibaba Cloud`](https://www.alibabacloud.com/).
-- `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [Ant Group](https://www.antfin.com/index.htm?locale=en_US).
+- `Eric Ernst` ([`egernst`](https://github.com/egernst)), [Apple](https://apple.com).
 - `Fabiano Fidêncio` ([`fidencio`](https://github.com/fidencio)), [Intel](https://www.intel.com).
+- `Feng Wang` ([`fengwang666`](https://github.com/fengwang666)), [`Confluent`](https://www.confluent.io).
+- `Gerry Liu` ([`jiangliu`](https://github.com/jiangliu)), [`Alibaba Cloud`](https://www.alibabacloud.com).
+- `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [Ant Group](https://www.antfin.com/index.htm?locale=en_US).
+- `Samuel Ortiz` ([`sameo`](https://github.com/sameo)), [`Rivos Inc`](https://www.rivosinc.com).
+- `Steve Horsman` ([`stevenhorsman`](https://github.com/stevenhorsman)), [`IBM`](https://www.ibm.com).
 
 Architecture Committee elections take place in the Autumn (3 seats available) and in the Spring (4 seats available). Anyone who has made contributions to the project will be eligible to run, and anyone who has had code merged into the Kata Containers project in the 12 months (a Contributor) before the election will be eligible to vote. There are no term limits, but in order to encourage diversity, no more than 2 of the 7 seats can be filled by any one organization.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The current Architecture Committee members are:
 - `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [Ant Group](https://www.antfin.com/index.htm?locale=en_US).
 - `Fabiano Fidêncio` ([`fidencio`](https://github.com/fidencio)), [Intel](https://www.intel.com).
 
-Architecture Committee elections take place in September (3 seats available) and February (2 seats available). Anyone who has made contributions to the project will be eligible to run, and anyone who has had code merged into the Kata Containers project in the 12 months (a Contributor) before the election will be eligible to vote. There are no term limits, but in order to encourage diversity, no more than 2 of the 5 seats can be filled by any one organization.
+Architecture Committee elections take place in the Autumn (3 seats available) and in the Spring (4 seats available). Anyone who has made contributions to the project will be eligible to run, and anyone who has had code merged into the Kata Containers project in the 12 months (a Contributor) before the election will be eligible to vote. There are no term limits, but in order to encourage diversity, no more than 2 of the 7 seats can be filled by any one organization.
 
 The exact size and model for the Architecture Committee may evolve over time based on the needs and growth of the project, but the governing body will always be committed to openness, diversity and the principle that technical decisions are made by technical contributors.
 

--- a/elections/arch-committee-2023-04/Results.md
+++ b/elections/arch-committee-2023-04/Results.md
@@ -1,1 +1,22 @@
 # Architecture Committee Election Results: Apr 2023
+
+Six nominations were received for the April 2023 elections:
+
+- [`Archana Shinde`](https://github.com/amshinde)
+- [`Feng Wang`](https://github.com/fengwang666)
+- [`Jeremi Piotrowski`](https://github.com/jepio)
+- [`Samuel Ortiz`](https://github.com/sameo)
+- [`Steve Horsman`](https://github.com/stevenhorsman)
+- [`Tao Peng`](https://github.com/bergwolf)
+
+Four seats were available, so elections were held.
+
+The nominees elected to the positions were:
+
+- [`Feng Wang`](https://github.com/fengwang666)
+- [`Samuel Ortiz`](https://github.com/sameo)
+- [`Steve Horsman`](https://github.com/stevenhorsman)
+- [`Tao Peng`](https://github.com/bergwolf)
+
+Congratulations to our new architecture committee members `Feng` and `Steve`,
+and to our continuing members `Samuel` and `Tao`!

--- a/elections/tools/generate_electorate.py
+++ b/elections/tools/generate_electorate.py
@@ -81,6 +81,7 @@ end_time = datetime.datetime(2018, 8, 1, 0, 0, 0, tzinfo=pytz.UTC)
 number = -1
 projects = []
 ignored_repos = [
+        'edk2',
         'qemu',
         'linux',
         'project-infra',
@@ -88,6 +89,7 @@ ignored_repos = [
         'resolve-pr-refs',
         'is-organization-member',
         'osbuilder',
+        'proxy',
         'runtime',
         'shim',
         'packaging',
@@ -95,6 +97,11 @@ ignored_repos = [
         'documentation',
         'agent',
         'slash-command-action',
+        'tests-1',
+        'kata-containers-github-actions-tests',
+        'kata-containers-cache-kernel',
+        'kata-containers-2',
+        'kata-containers-1',
         ]
 
 author_cache = {}


### PR DESCRIPTION
My fellow Kata citizens,

The voting period ended on May 1st, and I'm excited to announce the
results of the Kata Containers Architecture Committee elections.

We had 6 candidates and 4 seats to fill up. The voters elected the
following members:

- Tao Peng
- Feng Wang
- Samuel Ortiz
- Steve Horsman

Congratulations to our new Architecture Committee members Feng and
Steve, and to Tao and Samuel for renewing their seats!

For more details about the ballot, please use the following link:
https://civs1.civs.us/cgi-bin/results.pl?id=E_55f8c62ec8ce23da

Please note that we are using the CIVS default completion rule
(Minimax) to build the election results.