### PR TITLE
Adding 2024 H1 AC election details

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -84,12 +84,15 @@ See the [election tools documentation](tools).
 
 ## Current elections
 
-- October 2023
-  - [election](arch-committee-2023-10)
-  - [results](arch-committee-2023-10/Results.md)
+- April 2024
+  - [election](arch-committee-2024-04)
+  - [results](arch-committee-2024-04/Results.md)
 
 ## Previous elections
 
+- October 2023
+  - [election](arch-committee-2023-10)
+  - [results](arch-committee-2023-10/Results.md)
 
 - April 2023
   - [election](arch-committee-2023-04)

--- a/elections/arch-committee-2024-04/README.md
+++ b/elections/arch-committee-2024-04/README.md
@@ -1,0 +1,14 @@
+# Architecture Committee Elections: Apr 2024
+
+There are three Architecture Committee seats up for election. The seats up for
+election are currently filled by `Peng Tao`, `Samuel Ortiz` and `Steve Horsman`.
+
+Refer to the [elections folder README](https://github.com/kata-containers/community/tree/main/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* April 08, 15:00 UTC - April 15, 2024 14:59 UTC: Candidate nominations open
+* April 15, 15:00 UTC - April 22, 2024 14:59 UTC: Q&A/Debate period
+* April 22, 15:00 UTC - April 29, 2024 14:59 UTC: Voting open
+* April 30, 2024, results announced

--- a/elections/arch-committee-2024-04/Results.md
+++ b/elections/arch-committee-2024-04/Results.md
@@ -1,0 +1,10 @@
+# Architecture Committee Election Results: Apr 2024
+
+# nominations were received for the April 2024 elections:
+
+-
+
+The nominees elected to the positions were:
+
+-
+


### PR DESCRIPTION
This patch creates the folder for the 2024 H1 AC elections. It also proposes an election timeline that intentionally avoids the dates of KubeCon EU and Easter.