### PR TITLE
Specifying timeline for defining the electorate

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -36,8 +36,8 @@ mailing lists to learn the candidates platforms
 
 [Contributors](https://github.com/kata-containers/community#contributor)
 (defined as anyone who has had code merged in the Kata Containers
-project in the last 12 months) are eligible to vote in Architecture
-Committee elections.
+project in the last 12 months prior to the first day of the nomination period)
+are eligible to vote in Architecture Committee elections.
 
 ## Candidacy
 


### PR DESCRIPTION
This patch specifies the first day of the nomination period as the last day for anyone to qualify as eligible electorate.

This will help with building the electorate list earlier in the process, so election officials can make sure that everyone is included before creating the poll for the voting period.