### PR TITLE
Adding 2024 H2 AC election timeline

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -84,11 +84,14 @@ See the [election tools documentation](tools).
 
 ## Current elections
 
+- October 2024
+  - [election](arch-committee-2024-10)
+  
+## Previous elections
+
 - April 2024
   - [election](arch-committee-2024-04)
   - [results](arch-committee-2024-04/Results.md)
-
-## Previous elections
 
 - October 2023
   - [election](arch-committee-2023-10)

--- a/elections/arch-committee-2024-10/README.md
+++ b/elections/arch-committee-2024-10/README.md
@@ -1,0 +1,15 @@
+# Architecture Committee Elections: Oct 2024
+
+There are three Architecture Committee seats up for election. The seats up for
+election are currently filled by `Fupan Li`, `Gerry Liu` and `Greg Kurz`.
+
+Refer to the [elections folder README](https://github.com/kata-containers/community/tree/main/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* September 23, 2024: Election officials are confirmed: 
+* October 01, 15:00 UTC - October 08, 2024 14:59 UTC: Candidate nominations open
+* October 08, 15:00 UTC - October 15, 2024 14:59 UTC: Q&A/Debate period
+* October 15, 15:00 UTC - October 22, 2024 14:59 UTC: Voting open
+* October 22, 2024, results announced


### PR DESCRIPTION
This patch adds the timeline and creates the folder structure for the 2024 H4 AC election.