### PR TITLE
Adding election officials to Kata AC 2024 H2 election

### DIFF
--- a/elections/arch-committee-2024-10/README.md
+++ b/elections/arch-committee-2024-10/README.md
@@ -8,7 +8,7 @@ for election process, declaring candidacy, and eligible voters.
 
 Election Dates:
 
-* September 23, 2024: Election officials are confirmed: 
+* September 23, 2024: Election officials are confirmed: @Apokleos, @stevenhorsman
 * October 01, 15:00 UTC - October 08, 2024 14:59 UTC: Candidate nominations open
 * October 08, 15:00 UTC - October 15, 2024 14:59 UTC: Q&A/Debate period
 * October 15, 15:00 UTC - October 22, 2024 14:59 UTC: Voting open


### PR DESCRIPTION
This patch adds  Alex Lyn and Steve Horsman as election officials for the upcoming Kata AC elections.