### PR TITLE
election: 2024-10: Update dates

### DIFF
--- a/elections/arch-committee-2024-10/README.md
+++ b/elections/arch-committee-2024-10/README.md
@@ -9,7 +9,7 @@ for election process, declaring candidacy, and eligible voters.
 Election Dates:
 
 * September 23, 2024: Election officials are confirmed: @Apokleos, @stevenhorsman
-* October 01, 15:00 UTC - October 08, 2024 14:59 UTC: Candidate nominations open
-* October 08, 15:00 UTC - October 15, 2024 14:59 UTC: Q&A/Debate period
-* October 15, 15:00 UTC - October 22, 2024 14:59 UTC: Voting open
-* October 22, 2024, results announced
+* October 01, 15:00 UTC - October 15, 2024 14:59 UTC: Candidate nominations open
+* October 15, 15:00 UTC - October 22, 2024 14:59 UTC: Q&A/Debate period
+* October 22, 15:00 UTC - October 29, 2024 14:59 UTC: Voting open
+* October 29, 2024, results announced


### PR DESCRIPTION
Due to Golden week public holidays in China syncing with the candidate nomination period, we are extending this by a week and pushing the other dates back by the same in order to give everyone the chance to declare their candidacy