### PR TITLE
readme: update AC following 2024 H2 elections

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The Architecture Committee is responsible for architectural decisions, including
 The current Architecture Committee members are:
 
 - `Anastassios Nanos` ([`ananos`](https://github.com/ananos)), [`Nubificus Ltd`](https://nubificus.co.uk).
+- `Aurelien Bombo` ([`sprt`](https://github.com/sprt)), [`Microsoft`](https://www.microsoft.com/en-us/).
 - `Fupan Li` ([`lifupan`](https://github.com/lifupan)), [`Ant Group`](https://www.antgroup.com/en).
-- `Gerry Liu` ([`jiangliu`](https://github.com/jiangliu)), [`Alibaba Cloud`](https://www.alibabacloud.com).
 - `Greg Kurz` ([`gkurz`](https://github.com/gkurz)), [`Red Hat`](https://www.redhat.com).
 - `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [`Ant Group`](https://www.antgroup.com/en).
 - `Steve Horsman` ([`stevenhorsman`](https://github.com/stevenhorsman)), [`IBM`](https://www.ibm.com).

--- a/elections/README.md
+++ b/elections/README.md
@@ -101,7 +101,8 @@ execute the AC election.
 
 - October 2024
   - [election](arch-committee-2024-10)
-  
+  - [results](arch-committee-2024-10/Results.md)
+
 ## Previous elections
 
 - April 2024

--- a/elections/arch-committee-2024-10/Results.md
+++ b/elections/arch-committee-2024-10/Results.md
@@ -1,0 +1,18 @@
+# Architecture Committee Election Results: Oct 2024
+
+Four nominations were received for the October 2024 elections, however
+one of the candidates withdrew before the voting period. The final
+candidate list is:
+
+- [`Aurelien Bombo`](https://github.com/sprt)
+- [`Fupan Li`](https://github.com/lifupan)
+- [`Greg Kurz`](https://github.com/gkurz)
+
+Three seats were available, and the architecture committee resulting from
+the above nominations would not contain more than two members of the
+same affiliation, so the voting phase was skipped and all the nominated
+individuals were appointed to the architecture committee.
+
+Congratulations to our new architecture committee member `Aurélien`
+and to our continuing members `Fupan` and `Greg`!
+


### PR DESCRIPTION
This patch updates the AC after the election in October 2024. The patch removes Gerry Liu and adds Aurelien Bombo to the currnet AC.