### PR TITLE
Adding 2025 H1 AC election details

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -99,11 +99,15 @@ execute the AC election.
 
 ## Current elections
 
+- April 2025
+  - [election](arch-committee-2025-04)
+  - [results](arch-committee-2025-04/Results.md)
+
+## Previous elections
+
 - October 2024
   - [election](arch-committee-2024-10)
   - [results](arch-committee-2024-10/Results.md)
-
-## Previous elections
 
 - April 2024
   - [election](arch-committee-2024-04)

--- a/elections/arch-committee-2025-04/README.md
+++ b/elections/arch-committee-2025-04/README.md
@@ -1,0 +1,16 @@
+# Architecture Committee Elections: Apr 2025
+
+There are four Architecture Committee seats up for election. The seats up for
+election are currently filled by `Anastassios Nanos`, `Peng Tao`, `Steve Horsman`
+and `Zvonko Kaiser`.
+
+Refer to the [elections folder README](https://github.com/kata-containers/community/tree/main/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* March 31, 2025: Election officials are confirmed:
+* April 07, 15:00 UTC - April 14, 2025 14:59 UTC: Candidate nominations open
+* April 14, 15:00 UTC - April 21, 2025 14:59 UTC: Q&A/Debate period
+* April 21, 15:00 UTC - April 28, 2025 14:59 UTC: Voting open
+* April 28, 2025, results announced

--- a/elections/arch-committee-2025-04/Results.md
+++ b/elections/arch-committee-2025-04/Results.md
@@ -1,0 +1,9 @@
+# Architecture Committee Election Results: Apr 2025
+
+There were X nominations received for the April 2025 elections:
+
+- TBD
+
+Four seats were available, 
+
+Congratulations to ...


### PR DESCRIPTION
This patch creates the folder for the 2025 H1 AC elections. It also proposes an election timeline that intentionally avoids the dates of KubeCon EU.