### PR TITLE
readme: update AC following 2025 H1 elections

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The current Architecture Committee members are:
 - `Aurelien Bombo` ([`sprt`](https://github.com/sprt)), [`Microsoft`](https://www.microsoft.com/en-us/).
 - `Fupan Li` ([`lifupan`](https://github.com/lifupan)), [`Ant Group`](https://www.antgroup.com/en).
 - `Greg Kurz` ([`gkurz`](https://github.com/gkurz)), [`Red Hat`](https://www.redhat.com).
-- `Peng Tao` ([`bergwolf`](https://github.com/bergwolf)), [`Ant Group`](https://www.antgroup.com/en).
+- `Ruoqing He` ([`RuoqingHe`](https://github.com/RuoqingHe)), [`ISCAS`](http://english.is.cas.cn).
 - `Steve Horsman` ([`stevenhorsman`](https://github.com/stevenhorsman)), [`IBM`](https://www.ibm.com).
 - `Zvonko Kaiser` ([`zvonkok`](https://github.com/zvonkok)), [`NVIDIA`](https://www.nvidia.com).
 

--- a/elections/arch-committee-2025-04/Results.md
+++ b/elections/arch-committee-2025-04/Results.md
@@ -1,9 +1,21 @@
 # Architecture Committee Election Results: Apr 2025
 
-There were X nominations received for the April 2025 elections:
+There were 5 nominations received for the April 2025 elections:
 
-- TBD
+- [`Anastassios Nanos`](https://github.com/ananos)
+- [`Peng Tao`](https://github.com/bergwolf)
+- [`Steve Horsman`](https://github.com/stevenhorsman)
+- [`Ruoqing He`](https://github.com/RuoqingHe)
+- [`Zvonko Kaiser`](https://github.com/zvonkok)
 
-Four seats were available, 
+Four seats were available, so elections were held.
 
-Congratulations to ...
+The nominees elected to the positions were:
+
+- [`Anastassios Nanos`](https://github.com/ananos)
+- [`Steve Horsman`](https://github.com/stevenhorsman)
+- [`Ruoqing He`](https://github.com/RuoqingHe)
+- [`Zvonko Kaiser`](https://github.com/zvonkok)
+
+Congratulations to our new architecture committee member `Ruoqing`,
+and to our continuing members `Anastassios`, `Steve` and `Zvonk`!


### PR DESCRIPTION
This patch updates the AC after the election in April 2025. The patch removes Peng Tao and adds Rouqing He to the currnet AC.