### PR TITLE
Add April 2026 AC election details

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -99,11 +99,19 @@ execute the AC election.
 
 ## Current elections
 
+- April 2026
+  - [election](arch-committee-2026-04)
+  - [results](arch-committee-2026-04/Results.md)
+
+## Previous elections
+
+- October 2025
+  - [election](arch-committee-2025-10)
+  - [results](arch-committee-2025-10/Results.md)
+
 - April 2025
   - [election](arch-committee-2025-04)
   - [results](arch-committee-2025-04/Results.md)
-
-## Previous elections
 
 - October 2024
   - [election](arch-committee-2024-10)

--- a/elections/arch-committee-2026-04/README.md
+++ b/elections/arch-committee-2026-04/README.md
@@ -1,0 +1,16 @@
+# Architecture Committee Elections: Apr 2026
+
+There are four Architecture Committee seats up for election. The seats up for
+election are currently filled by `Anastassios Nanos`, `Steve Horsman`, `Ruoqing He`
+and `Zvonko Kaiser`.
+
+Refer to the [elections folder README](https://github.com/kata-containers/community/tree/main/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* March 31, 2026: Election officials are confirmed:
+* April 07, 15:00 UTC - April 14, 2026 14:59 UTC: Candidate nominations open
+* April 14, 15:00 UTC - April 21, 2026 14:59 UTC: Q&A/Debate period
+* April 21, 15:00 UTC - April 28, 2026 14:59 UTC: Voting open
+* April 28, 2026, results announced

--- a/elections/arch-committee-2026-04/Results.md
+++ b/elections/arch-committee-2026-04/Results.md
@@ -1,0 +1,13 @@
+# Architecture Committee Election Results: Apr 2026
+
+There were [TBD] nominations received for the April 2026 elections:
+
+- 
+
+Four seats were available, so elections were held.
+
+The nominees elected to the positions were:
+
+- 
+
+Congratulations to 


### PR DESCRIPTION
This patch adds the folder structure and proposed timeframe for the April, 2026 Kata AC election.

It also adds the missing pointers to the October, 2025 AC election to the main README file for elections.