### PR TITLE
static-checks: Remove the use of install_go

### DIFF
--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -22,11 +22,9 @@ clone_kata_repo() {
 	fi
 }
 
-run_static_checks()
-{
+run_static_checks() {
 	clone_kata_repo
 	INSTALL_IN_GOPATH=false bash "${kata_repo_dir}/ci/install_yq.sh"
-	bash "${kata_repo_dir}/tests/install_go.sh" -f -p
 	bash "${kata_repo_dir}/tests/static-checks.sh" "github.com/kata-containers/community"
 }
 

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -26,7 +26,7 @@ clone_kata_repo() {
 run_static_checks() {
 	clone_kata_repo
 	INSTALL_IN_GOPATH=false bash "${kata_repo_dir}/ci/install_yq.sh"
-	bash "${kata_repo_dir}/tests/static-checks.sh" "github.com/kata-containers/community"
+	bash "${kata_repo_dir}/tests/static-checks.sh"
 }
 
 run_static_checks

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -20,6 +20,7 @@ clone_kata_repo() {
 		git checkout "${kata_default_branch}"
 		popd || exit
 	fi
+	ls -R "${kata_repo_dir}"
 }
 
 run_static_checks() {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
         run: |
           sudo apt-get -y install moreutils hunspell hunspell-en-gb hunspell-en-us pandoc
 
+      - name: Setup Golang version ${{ env.GO_VERSION }}
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+
       - name: Running static checks
         run: |
           export PATH=${GOPATH}/bin:${PATH}


### PR DESCRIPTION
We are removing install_go from the kata repo, so replace it with the setup-go action here.