### PR TITLE
Mark the old VMT process outdated

### DIFF
--- a/VMT/KCSA.md
+++ b/VMT/KCSA.md
@@ -1,4 +1,11 @@
-# Kata Containers Security Advisories
+# Kata Containers Security Advisories - ARCHIVED
+
+> [!WARNING]  
+> Please note that this document is ARCHIVED and replaced by a new process defined by the Kata Containers Vulnerability Management Team (VMT).
+> The list of published security advisories is now available on the [security tab](https://github.com/kata-containers/kata-containers/security/advisories?state=published)
+> in the kata-containers repository.
+> If you found a vulnerability that you need to report, please follow the [security guidelines for vulnerability reporting](https://github.com/kata-containers/kata-containers/blob/main/SECURITY.md).
+
 
 * [Kata Containers Security Advisories](#kata-containers-security-advisories)
     * [KCSA summary](#kcsa-summary)

--- a/VMT/VMT.md
+++ b/VMT/VMT.md
@@ -1,4 +1,11 @@
-# Vulnerability Management Process
+# Vulnerability Management Process - DOCUMENT UNDER MAINTENANCE
+
+> [!WARNING]  
+> Please note that this document is OUTDATED and is currently being revised by the Kata Containers Vulnerability Management Team (VMT).
+> If you found a vulnerability that you need to report, please follow the [security guidelines for vulnerability reporting](https://github.com/kata-containers/kata-containers/blob/main/SECURITY.md).
+> You can also find the list of published security advisories on the [security tab](https://github.com/kata-containers/kata-containers/security/advisories?state=published)
+> in the kata-containers repository.
+
 
 > The Kata Containers vulnerability management policy is derived from the [OpenStack Vulnerability Management Process](https://security.openstack.org/vmt-process.html) and licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/legalcode)
 


### PR DESCRIPTION
This patch highlights that there is a new VMT process under construction and marks old documents archived and outdated. It also adds pointers to the new process documents and placement for security advisories.