### PR TITLE
This patch adds timeline for the 2026 H2 AC election

### DIFF
--- a/elections/README.md
+++ b/elections/README.md
@@ -99,7 +99,9 @@ execute the AC election.
 
 ## Current elections
 
-- October 2026 - TBA
+- October 2026
+  - [election](arch-committee-2026-10)
+  - [results](arch-committee-2026-10/Results.md)
 
 ## Previous elections
 

--- a/elections/arch-committee-2026-10/README.md
+++ b/elections/arch-committee-2026-10/README.md
@@ -1,0 +1,15 @@
+# Architecture Committee Elections: Oct 2026
+
+There are three Architecture Committee seats up for election. The seats up for
+election are currently filled by `Aurelien Bombo`, `Fupan Li` and `Greg Kurz`.
+
+Refer to the [elections folder README](https://github.com/kata-containers/community/tree/main/elections)
+for election process, declaring candidacy, and eligible voters.
+
+Election Dates:
+
+* September 22, 2026: Election officials are confirmed: 
+* September 29, 15:00 UTC - October 09, 2026 14:59 UTC: Candidate nominations open
+* October 09, 15:00 UTC - October 20, 2026 14:59 UTC: Q&A/Debate period
+* October 20, 15:00 UTC - October 27, 2026 14:59 UTC: Voting open
+* October 27, 2026, results announced

--- a/elections/arch-committee-2026-10/Results.md
+++ b/elections/arch-committee-2026-10/Results.md
@@ -1,0 +1,9 @@
+# Architecture Committee Election Results: October 2026
+
+[NUMBER OF] nominations were received for the October 2026 elections:
+
+- [`NAME`](LINK TO GH USER)
+
+Three seats were available, and ...
+
+Congratulations to our continuing members NAME(S) and NAME(S)!


### PR DESCRIPTION
The patch adds a new election folder with the election timeline and a template for the file that is going to contain the election results when available. The main election README is also update to point at the resources of the upcoming election.